### PR TITLE
Fix cleared highlight when colorscheme loading

### DIFF
--- a/plugin/ddc_source_lsp.vim
+++ b/plugin/ddc_source_lsp.vim
@@ -1,2 +1,9 @@
+augroup ddc-source-lsp
+  autocmd!
+  " Cleared default highlights without link when applying colorscheme
+  " so redefine it.
+  autocmd ColorScheme * highlight default DdcLspDeprecated
+        \ term=strikethrough cterm=strikethrough gui=strikethrough
+augroup END
 highlight default DdcLspDeprecated
       \ term=strikethrough cterm=strikethrough gui=strikethrough


### PR DESCRIPTION
Cleared default highlights without link when applying colorscheme, so redefine it.