### PR TITLE
sourceParams.bufnrの追加

### DIFF
--- a/denops/ddc-source-lsp/client.ts
+++ b/denops/ddc-source-lsp/client.ts
@@ -12,17 +12,17 @@ export type Client = {
 export async function getClients(
   denops: Denops,
   lspEngine: Params["lspEngine"],
+  bufnr?: number,
 ): Promise<Client[]> {
   if (lspEngine === "nvim-lsp") {
     return await denops.call(
       "luaeval",
-      `require("ddc_source_lsp.internal").get_clients()`,
+      `require("ddc_source_lsp.internal").get_clients(${bufnr ?? 0})`,
     ) as Client[];
   } else if (lspEngine === "vim-lsp") {
-    const bufnr = await fn.bufnr(denops);
     const servers = await denops.call(
       "lsp#get_allowed_servers",
-      bufnr,
+      bufnr ?? await fn.bufnr(denops),
     ) as string[];
     const clients: Client[] = [];
     for (const server of servers) {
@@ -42,11 +42,10 @@ export async function getClients(
     }
     return clients;
   } else if (lspEngine === "lspoints") {
-    const bufnr = await fn.bufnr(denops);
     return (await denops.dispatch(
       "lspoints",
       "getClients",
-      bufnr,
+      bufnr ?? await fn.bufnr(denops),
     ) as {
       id: number;
       serverCapabilities: LSP.ServerCapabilities;

--- a/denops/ddc-source-lsp/client.ts
+++ b/denops/ddc-source-lsp/client.ts
@@ -17,7 +17,8 @@ export async function getClients(
   if (lspEngine === "nvim-lsp") {
     return await denops.call(
       "luaeval",
-      `require("ddc_source_lsp.internal").get_clients(${bufnr ?? 0})`,
+      `require("ddc_source_lsp.internal").get_clients(_A[1])`,
+      [bufnr],
     ) as Client[];
   } else if (lspEngine === "vim-lsp") {
     const servers = await denops.call(

--- a/denops/ddc-source-lsp/deps/lsp.ts
+++ b/denops/ddc-source-lsp/deps/lsp.ts
@@ -8,10 +8,7 @@ export {
   type OffsetEncoding,
   parseSnippet,
   toUtf16Index,
-} from "https://deno.land/x/denops_lsputil@v0.9.3/mod.ts";
-
-export {
   uriFromBufnr,
-} from "https://deno.land/x/denops_lsputil@v0.9.3/uri/mod.ts";
+} from "https://deno.land/x/denops_lsputil@v0.9.3/mod.ts";
 
 export * as LSP from "npm:vscode-languageserver-protocol@3.17.6-next.1";

--- a/denops/ddc-source-lsp/deps/lsp.ts
+++ b/denops/ddc-source-lsp/deps/lsp.ts
@@ -10,4 +10,8 @@ export {
   toUtf16Index,
 } from "https://deno.land/x/denops_lsputil@v0.9.3/mod.ts";
 
+export {
+  uriFromBufnr,
+} from "https://deno.land/x/denops_lsputil@v0.9.3/uri/mod.ts";
+
 export * as LSP from "npm:vscode-languageserver-protocol@3.17.6-next.1";

--- a/denops/ddc-source-lsp/request.ts
+++ b/denops/ddc-source-lsp/request.ts
@@ -21,7 +21,7 @@ export async function request(
           opts.client.id,
           method,
           params,
-          { timemout: opts.timeout, bufnr: opts.bufnr ?? 0 },
+          { timemout: opts.timeout, bufnr: opts.bufnr },
         ],
       );
     } else {
@@ -37,7 +37,7 @@ export async function request(
         [opts.client.id, method, params, {
           plugin_name: denops.name,
           lambda_id,
-          bufnr: opts.bufnr ?? 0,
+          bufnr: opts.bufnr,
         }],
       );
       return deadline(waiter.promise, opts.timeout);

--- a/denops/ddc-source-lsp/request.ts
+++ b/denops/ddc-source-lsp/request.ts
@@ -1,5 +1,6 @@
 import { Denops, fn, register } from "./deps/denops.ts";
 import { deadline, DeadlineError } from "./deps/std.ts";
+import { uriFromBufnr } from "./deps/lsp.ts";
 import { is, u } from "./deps/unknownutil.ts";
 import { Params } from "../@ddc-sources/lsp.ts";
 import { Client } from "./client.ts";
@@ -74,6 +75,18 @@ export async function request(
       }
     }
   } else if (lspEngine === "lspoints") {
+    if (opts.bufnr != null && opts.bufnr > 0 && is.Record(params)) {
+      return await denops.dispatch(
+        "lspoints",
+        "request",
+        opts.client.id,
+        method,
+        {
+          ...params,
+          textDocument: { uri: await uriFromBufnr(denops, opts.bufnr) },
+        },
+      );
+    }
     return await denops.dispatch(
       "lspoints",
       "request",

--- a/doc/ddc-source-lsp.txt
+++ b/doc/ddc-source-lsp.txt
@@ -83,6 +83,17 @@ To take advantage of all the features, you need to set client_capabilities.
 ==============================================================================
 PARAMS                                                 *ddc-source-lsp-params*
 
+                                                  *ddc-source-lsp-param-bufnr*
+bufnr			(number | v:null)
+		- number:	the number of a buffer
+		- v:null:	the current buffer
+
+		Specify the buffer to be used in requests to the language
+		server. Needs not be set for normal use. see FAQ
+		(|ddc-source-lsp-faq-markdown-codeblocks|).
+
+		Default: v:null
+
                                         *ddc-source-lsp-param-confirmBehavior*
 confirmBehavior		("insert" | "replace")
 		- "insert":	Inserts the selected item and moves adjacent
@@ -186,6 +197,59 @@ Q: The items are not displayed.
 A: You have enabled LSP snippet by "snippetSupport" in lspconfig.
 If you want to complete snippet items, you must configure
 |ddc-source-lsp-param-snippetEngine|. Otherwise, they are filtered.
+
+                                        *ddc-source-lsp-faq-markdown-codeblocks*
+Q: How to enable completions in markdown codeblocks?
+
+A: Use |ddc#custom#set_context_filetype()| and conditionally set the number of a
+virtual buffer to |ddc-source-lsp-param-bufnr|. The virual buffer should
+synchronize its content with the codeblock and should have an attached
+language server. In Neovim, otter.nvim (https://github.com/jmbuhr/otter.nvim)
+is the plugin to manage such buffers. Following is an example setup:
+
+>lua
+	-- Activate otter on markdown
+	vim.api.nvim_create_autocmd("Filetype", {
+	  pattern = "lua",
+	  callback = function()
+	    require("otter").activate(
+	      {"lua"}, -- languages to enable completions
+	      false -- disable completion with cmp
+	    )
+	  end
+	})
+
+	vim.fn["ddc#custom#set_context_filetype"]("markdown", function()
+	  local otter_keeper = require("otter.keeper")
+
+	  -- sync quarto buffer with otter buffers
+	  otter_keeper.sync_raft(ctx.buf)
+
+	  -- sourceParams based on the cursor positions
+	  local cursor = vim.api.nvim_win_get_cursor(0)
+	  local otter_attached = otter_keeper._otters_attached[ctx.buf]
+	  for _, chunks in pairs(otter_attached.code_chunks) do
+	    for _, chunk in pairs(chunks) do
+	      local srow, scol = chunk.range.from[1] + 1, chunk.range.from[2]
+	      local erow, ecol = chunk.range.to[1] + 1, chunk.range.to[2]
+	      if
+	        ((cursor[1] == srow and cursor[2] >= scol) or (cursor[1] > srow))
+	        and ((cursor[1] == erow and cursor[2] <= ecol) or cursor[1] < erow)
+	      then
+	        return {
+	          sourceParams = {
+	            lsp = { bufnr = otter_attached.buffers[chunk.lang] },
+	          },
+	        }
+	      end
+	    end
+	  end
+         
+	  -- if current cursor is not inside a codeblock, do nothing
+	  return {}
+	end)
+<
+
 
 ==============================================================================
 vim:tw=78:ts=8:ft=help:norl:noet:fen:noet:

--- a/doc/ddc-source-lsp.txt
+++ b/doc/ddc-source-lsp.txt
@@ -184,6 +184,7 @@ snippetIndicator	(string)
 ==============================================================================
 FREQUENTLY ASKED QUESTIONS (FAQ)                          *ddc-source-lsp-faq*
 
+                                       *ddc-source-lsp-faq-snippet-is-doubled*
 Q: The snippet is double expanded.
 
 A: Remove "vim-vsnip-integ" and use "ddc-source-vsnip" instead.
@@ -192,6 +193,7 @@ Since "vim-vsnip-integ" sets |:autocmd|, please remove it completely from
 
 https://github.com/uga-rosa/ddc-source-vsnip
 
+                                      *ddc-source-lsp-faq-items-not-displayed*
 Q: The items are not displayed.
 
 A: You have enabled LSP snippet by "snippetSupport" in lspconfig.

--- a/lua/ddc_source_lsp/internal.lua
+++ b/lua/ddc_source_lsp/internal.lua
@@ -5,12 +5,13 @@ local M = {}
 ---@field provider table
 ---@field offsetEncoding string
 
+---@param bufnr number?
 ---@return Client[]
-function M.get_clients()
+function M.get_clients(bufnr)
   local clients = {}
   ---@diagnostic disable-next-line: deprecated
   local get_clients = vim.lsp.get_clients or vim.lsp.get_active_clients
-  for _, client in pairs(get_clients({ bufnr = 0 })) do
+  for _, client in pairs(get_clients({ bufnr = bufnr or 0 })) do
     local provider = client.server_capabilities.completionProvider
     if provider then
       table.insert(clients, {
@@ -45,7 +46,7 @@ end
 ---@param clientId number
 ---@param method string
 ---@param params table
----@param opts { plugin_name: string, lambda_id: string }
+---@param opts { plugin_name: string, lambda_id: string, bufnr: number? }
 ---@return unknown?
 function M.request(clientId, method, params, opts)
   local client = vim.lsp.get_client_by_id(clientId)
@@ -54,7 +55,7 @@ function M.request(clientId, method, params, opts)
       if err == nil and result then
         vim.fn["denops#notify"](opts.plugin_name, opts.lambda_id, { result })
       end
-    end, 0)
+    end, opts.bufnr or 0)
   end
 end
 
@@ -62,12 +63,12 @@ end
 ---@param clientId number
 ---@param method string
 ---@param params table
----@param opts { timeout: number }
+---@param opts { timeout: number, bufnr: number? }
 ---@return unknown?
 function M.request_sync(clientId, method, params, opts)
   local client = vim.lsp.get_client_by_id(clientId)
   if client then
-    return client.request_sync(method, normalize(params), opts.timeout, 0)
+    return client.request_sync(method, normalize(params), opts.timeout, opts.bufnr or 0)
   end
 end
 


### PR DESCRIPTION
otter.nvim + nvim-cmp では、markdown中のコードブロックなどから仮想バッファを生成し、仮想バッファのLSP補完をmarkdownの補完として流用しています。

同様の方法をddc-source-lspで実装するために、`sourceParams.bufnr`を追加し、仮想バッファの補完候補を流用できるようにしました。