### PR TITLE
fix: ensure server supports executeCommand

### DIFF
--- a/lua/ddc_source_lsp/internal.lua
+++ b/lua/ddc_source_lsp/internal.lua
@@ -76,7 +76,7 @@ end
 ---@param command lsp.Command
 function M.execute(clientId, command)
   local client = vim.lsp.get_client_by_id(clientId)
-  if client == nil then
+  if client == nil or not client.server_capabilities.executeCommandProvider then
     return
   end
   command.title = nil


### PR DESCRIPTION
Some LSP servers do not support `workspace/executeCommand` like the CSS language server (https://github.com/hrsh7th/vscode-langservers-extracted)

This will check the server capability before calling the request.

Here is the error I get:


https://github.com/Shougo/ddc-source-lsp/assets/3767728/bee4dc33-118f-40eb-ac71-122d4aa4cabc

