### PR TITLE
Fix inconsistent return value of request function

### DIFF
--- a/denops/@ddc-sources/lsp.ts
+++ b/denops/@ddc-sources/lsp.ts
@@ -260,9 +260,9 @@ export class Source extends BaseSource<Params> {
         lspItem,
         { client, timeout: 1000, sync: true, bufnr: bufnr },
       );
-      const { result } = u.ensure(
+      const result = u.ensure(
         response,
-        is.ObjectOf({ result: is.ObjectOf({ label: is.String }) }),
+        is.ObjectOf({ label: is.String }),
       );
       return result as LSP.CompletionItem;
     } catch {

--- a/lua/ddc_source_lsp/internal.lua
+++ b/lua/ddc_source_lsp/internal.lua
@@ -68,7 +68,10 @@ end
 function M.request_sync(clientId, method, params, opts)
   local client = vim.lsp.get_client_by_id(clientId)
   if client then
-    return client.request_sync(method, normalize(params), opts.timeout, opts.bufnr or 0)
+    local resp = client.request_sync(method, normalize(params), opts.timeout, opts.bufnr or 0)
+    if resp and resp.err == nil and resp.result then
+      return resp.result
+    end
   end
 end
 


### PR DESCRIPTION
When `lspEngine==nvim-lsp && opt.sync==true`, the request function in `request.ts` returns `response: {err?: lsp.ResponseError, result: unknown}`. Otherwise, it returns `response.result: unknown`.

By unifying the return value to `response.result: unknown`, Source.#resolve will work when `lspEngine==lspoints`.

Note: When `lspEngine==vim-lsp`, Source.#resolve does not work due to another problem.