### PR TITLE
Fix typos

### DIFF
--- a/denops/@ddc-sources/lsp/request.ts
+++ b/denops/@ddc-sources/lsp/request.ts
@@ -27,7 +27,7 @@ export async function request(
           opts.client.id,
           method,
           params,
-          { timemout: opts.timeout, bufnr: opts.bufnr },
+          { timeout: opts.timeout, bufnr: opts.bufnr },
         ],
       );
     } else {

--- a/doc/ddc-source-lsp.txt
+++ b/doc/ddc-source-lsp.txt
@@ -221,7 +221,7 @@ If you want to complete snippet items, you must configure
 Q: How to enable completions in markdown codeblocks?
 
 A: Use |ddc#custom#set_context_filetype()| and conditionally set the number of
-a virtual buffer to |ddc-source-lsp-param-bufnr|. The virual buffer should
+a virtual buffer to |ddc-source-lsp-param-bufnr|. The virtual buffer should
 synchronize its content with the codeblock and should have an attached
 language server. In Neovim, otter.nvim (https://github.com/jmbuhr/otter.nvim)
 is the plugin to manage such buffers. Following is an example setup:


### PR DESCRIPTION
This Pull Requet fixes some typos. 

The `timeout` parameter for `nvim-lsp` may not have been passed as expected due to one of the typos.